### PR TITLE
Enabled autocorrect in text fields

### DIFF
--- a/app/src/main/res/layout/activity_advanced_item.xml
+++ b/app/src/main/res/layout/activity_advanced_item.xml
@@ -27,7 +27,7 @@
         android:layout_marginEnd="8dp"
         android:ems="10"
         android:hint="@string/content_hint"
-        android:inputType="text"
+        android:inputType="text|textAutoCorrect"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/itemLocation" />
@@ -74,7 +74,7 @@
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"
         android:ems="10"
-        android:inputType="textMultiLine"
+        android:inputType="textMultiLine|textAutoCorrect"
         android:hint="@string/item_notes_hint"
         android:gravity="top"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,7 +41,7 @@
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
         android:ems="10"
-        android:inputType="text"
+        android:inputType="text|textAutoCorrect"
         android:hint="@string/content_hint"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/activity_shortcut.xml
+++ b/app/src/main/res/layout/activity_shortcut.xml
@@ -32,7 +32,7 @@
         android:layout_height="wrap_content"
         android:ems="10"
         android:hint="@string/shortcut_name_hint"
-        android:inputType="text"
+        android:inputType="text|textAutoCorrect"
         android:maxLength="10"
         android:importantForAutofill="no"
         tools:targetApi="o" />

--- a/app/src/main/res/layout/fragment_item_list.xml
+++ b/app/src/main/res/layout/fragment_item_list.xml
@@ -49,7 +49,7 @@
             android:ems="10"
             android:backgroundTint="@android:color/transparent"
             android:hint="@string/content_hint"
-            android:inputType="text" />
+            android:inputType="text|textAutoCorrect" />
 
         <ImageButton
             android:id="@+id/submitButton"


### PR DESCRIPTION
Fixes #3 

Note that I specifically did not enable autocorrect in the auth token `EditText` field as it would not be appropriate in that context.

I don't have an active Android development setup right now, so this change is not tested. I would really appreciate if you could look through it and test it out before merging in, just quickly verifying that autocorrect is indeed enabled in the proper text fields. Thanks!

(republish of #4)